### PR TITLE
Set CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @frontapp/developers-platform


### PR DESCRIPTION
Set Developers Platform team as code owners for the repo. It is needed to reinforce restrictions to merge into the main branch.